### PR TITLE
Add organization links on dashboard index page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,5 @@ end
 
 group :development do
   gem 'web-console', '~> 2.0'
-  gem 'spring'
   gem 'pry-rails'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -161,7 +161,6 @@ GEM
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
     slop (3.6.0)
-    spring (1.6.4)
     sprockets (3.5.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -203,7 +202,6 @@ DEPENDENCIES
   rails (= 4.2.5.2)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  spring
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,4 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "badges";
+@import "organization";

--- a/app/assets/stylesheets/organization.scss
+++ b/app/assets/stylesheets/organization.scss
@@ -1,0 +1,7 @@
+.organization {
+  margin: 10px;
+
+  p {
+    margin-top: 10%;
+  }
+}

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,7 +1,7 @@
 class DashboardController < ApplicationController
   before_filter :authenticate_user
-  
-  def index
 
+  def index
+    @organization_groups = UserOrganizationsService.process(current_user).in_groups_of 3, false
   end
 end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,0 +1,8 @@
+class OrganizationsController < ApplicationController
+  def index
+  end
+
+  def show
+    @projects = Repositories::ByOrganizationService.process(current_user, params[:id]).repos
+  end
+end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,0 +1,5 @@
+class ProjectsController < ApplicationController
+  def show
+    @project = Repositories::ByIDService.process(current_user, *params.values_at(:organization_id, :id))
+  end
+end

--- a/app/models/externals/organization.rb
+++ b/app/models/externals/organization.rb
@@ -1,0 +1,7 @@
+class Externals::Organization
+  include ActiveAttr::Model
+
+  attribute :id
+  attribute :login
+  attribute :avatar_url
+end

--- a/app/services/repositories/by_id_service.rb
+++ b/app/services/repositories/by_id_service.rb
@@ -1,0 +1,12 @@
+class Repositories::ByIDService < Repositories::BaseService
+  def initialize(user, organization_name, project_name)
+    @user, @organization_name, @project_name = user, organization_name, project_name
+    super(@user)
+  end
+
+  def perform
+    @result = Externals::RepositoryContainer.new(@client.org_repos(@organization_name)).find_by(name: @project_name)
+
+    self
+  end
+end

--- a/app/services/user_organizations_service.rb
+++ b/app/services/user_organizations_service.rb
@@ -1,0 +1,11 @@
+class UserOrganizationsService < ApplicationService
+  def initialize(user)
+    @client = Octokit::Client.new(access_token: user.token)
+  end
+
+  def perform
+    @result = @client.organizations.map {|o| Externals::Organization.new o}
+
+    self
+  end
+end

--- a/app/views/dashboard/_organization.html.erb
+++ b/app/views/dashboard/_organization.html.erb
@@ -1,0 +1,8 @@
+<%= link_to '', class: 'col-md-3 btn btn-default organization' do %>
+  <div class="row">
+    <div class="th-badge col-md-4">
+      <%= image_tag organization.avatar_url, class: 'img-circle', width: '75px', height: '75px' %>
+    </div>
+    <p class="col-md-8"><%= organization.login %></p>
+  </div>
+<% end %>

--- a/app/views/dashboard/_organization.html.erb
+++ b/app/views/dashboard/_organization.html.erb
@@ -1,4 +1,4 @@
-<%= link_to '', class: 'col-md-3 btn btn-default organization' do %>
+<%= link_to organization_path(organization.login), class: 'col-md-3 btn-default organization' do %>
   <div class="row">
     <div class="th-badge col-md-4">
       <%= image_tag organization.avatar_url, class: 'img-circle', width: '75px', height: '75px' %>

--- a/app/views/dashboard/_organization_row.html.erb
+++ b/app/views/dashboard/_organization_row.html.erb
@@ -1,0 +1,3 @@
+<div class="row">
+  <%= render partial: 'organization', collection: organization_row %>
+</div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -23,13 +23,15 @@
     <div class="col-md-8">
       <div class="panel panel-primary">
         <div class="panel-heading">
-          <div class="panel-title">Badges</div>
+          <div class="panel-title">Organizações</div>
         </div>
 
         <div class="panel-body">
-          <div class="th-badge">
-            <%= image_tag image_path('badges/teamhero.png'), width: '75px', height: '75px' %>
-          </div>
+          <% @organization_groups.each do |group| %>
+            <div class="row">
+              <%= render partial: 'organization', collection: group%>
+            </div>
+          <% end %>
         </div>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,9 +10,9 @@
 <nav class="navbar navbar-default">
   <div class="container-fluid">
     <div class="navbar-header">
-      <a class="navbar-brand" href="#">
+      <%= link_to root_path do %>
         <%= image_tag image_path('badges/teamhero.png'), width: '30px', height: '30px' %>
-      </a>
+      <% end %>
     </div>
 
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">

--- a/app/views/organizations/_project.html.erb
+++ b/app/views/organizations/_project.html.erb
@@ -1,7 +1,7 @@
 <div class="row">
   <div class="col-md-8 panel panel-default">
     <div class="panel-body">
-      <%= project.name %>
+      <%= link_to project.name, organization_project_path(params[:id], project.name) %>
     </div>
   </div>
 </div>

--- a/app/views/organizations/_project.html.erb
+++ b/app/views/organizations/_project.html.erb
@@ -1,0 +1,7 @@
+<div class="row">
+  <div class="col-md-8 panel panel-default">
+    <div class="panel-body">
+      <%= project.name %>
+    </div>
+  </div>
+</div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,0 +1,11 @@
+<div class="container">
+  <div class="row">
+    <div class="well col-md-8">
+      <h2>Badges</h2>
+      <div class="th-badge">
+        <%= image_tag image_path('badges/teamhero.png'), width: '75px', height: '75px' %>
+      </div>
+    </div>
+  </div>
+  <%= render partial: 'project', collection: @projects %>
+</div>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -1,0 +1,10 @@
+<div class="container">
+  <div class="row">
+    <div class="well col-md-8">
+      <h2>Suas badges nesse projeto</h2>
+      <div class="th-badge">
+        <%= image_tag image_path('badges/teamhero.png'), width: '75px', height: '75px' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,6 @@ Rails.application.routes.draw do
   get '/login' => 'sessions#new'
   get '/auth/github/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy'
+
+  resources :organizations, only: [:index, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,7 @@ Rails.application.routes.draw do
   get '/auth/github/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy'
 
-  resources :organizations, only: [:index, :show]
+  resources :organizations, only: [:index, :show] do
+    resources :projects, only: :show
+  end
 end


### PR DESCRIPTION
Na index faz mais sentido mostrar as organizações do usuário. 
![screen shot 2016-03-24 at 12 17 26 am](https://cloud.githubusercontent.com/assets/583772/14007479/e5e18f70-f155-11e5-965d-ea080bb7b59f.png)

Depois vou criar a página de organização, onde serão listados os repositórios
